### PR TITLE
Align chat and lesson sidebars with full-height scrolling

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -14,15 +14,13 @@ interface ChatMessage {
 
 interface ChatInterfaceProps {
   onTimestampClick?: (videoId: string, timestamp: number) => void;
-  /** Overall fixed height in px (defaults to 320 for a smaller footprint) */
-  height?: number;
 }
 
 const generateSessionId = (): string =>
   Math.random().toString(36).substring(2, 15) +
   Math.random().toString(36).substring(2, 15);
 
-export const ChatInterface = ({ onTimestampClick, height = 320 }: ChatInterfaceProps) => {
+export const ChatInterface = ({ onTimestampClick }: ChatInterfaceProps) => {
   const [messages, setMessages] = useState<ChatMessage[]>([
     {
       id: '1',
@@ -35,13 +33,16 @@ export const ChatInterface = ({ onTimestampClick, height = 320 }: ChatInterfaceP
   const [inputValue, setInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [sessionId] = useState(() => generateSessionId());
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
   const { toast } = useToast();
 
   const WEBHOOK_URL = 'https://juanjogamez2.app.n8n.cloud/webhook/d69fdf7e-3f27-414c-abb2-bf9ffda43d78';
 
   const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const container = messagesContainerRef.current;
+    if (container) {
+      container.scrollTop = container.scrollHeight;
+    }
   };
 
   useEffect(() => {
@@ -243,10 +244,7 @@ export const ChatInterface = ({ onTimestampClick, height = 320 }: ChatInterfaceP
   };
 
   return (
-    <div
-      className="flex flex-col bg-card rounded-lg border overflow-hidden"
-      style={{ height }} // smaller by default, easily adjustable
-    >
+    <div className="flex flex-col h-full bg-card rounded-lg border overflow-hidden">
       {/* Header (made tighter) */}
       <div className="px-3 py-2 bg-primary border-b flex justify-between items-center">
         <h3 className="text-xs font-semibold text-white">Chat</h3>
@@ -257,7 +255,7 @@ export const ChatInterface = ({ onTimestampClick, height = 320 }: ChatInterfaceP
 
       {/* Messages (the only scrollable area) */}
       <div className="flex-1 flex flex-col px-2 py-2">
-        <div className="flex-1 overflow-y-auto space-y-2 pr-1">
+        <div ref={messagesContainerRef} className="flex-1 overflow-y-auto space-y-2 pr-1">
           {messages.map((message) => (
             <div
               key={message.id}
@@ -315,8 +313,6 @@ export const ChatInterface = ({ onTimestampClick, height = 320 }: ChatInterfaceP
               </div>
             </div>
           )}
-
-          <div ref={messagesEndRef} />
         </div>
 
         {/* Input (compact) */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -140,11 +140,10 @@ const Index = () => {
     if (lesson) {
       setCurrentLesson(lesson);
       setStartTime(timestamp);
-      
+
       setTimeout(() => {
-        if ((window as any).seekToTime) {
-          (window as any).seekToTime(timestamp);
-        }
+        type WindowWithSeek = Window & { seekToTime?: (time: number) => void };
+        (window as WindowWithSeek).seekToTime?.(timestamp);
       }, 1000);
     }
   };
@@ -152,11 +151,11 @@ const Index = () => {
   const completedLessons = sampleLessons.filter(lesson => lesson.completed).length;
 
   return (
-    <div className="h-screen bg-background flex flex-col">
+    <div className="h-screen bg-background flex flex-col overflow-hidden">
       {/* Main Content */}
-      <div className="flex-1 grid grid-cols-1 lg:grid-cols-10 gap-1">
+      <div className="flex-1 grid grid-cols-1 lg:grid-cols-10 gap-1 overflow-hidden">
         {/* Video area */}
-        <div className="lg:col-span-6 p-4 flex flex-col h-full">
+        <div className="lg:col-span-6 p-4 flex flex-col h-full overflow-hidden">
           <div className="aspect-video bg-black rounded-lg overflow-hidden shadow-lg">
             <YouTubePlayer
               key={currentLesson.videoId}
@@ -165,9 +164,9 @@ const Index = () => {
               startTime={startTime}
             />
           </div>
-          
+
           {/* Current Lesson Info */}
-          <div className="mt-4 p-4 bg-card rounded-lg border flex-1">
+          <div className="mt-4 p-4 bg-card rounded-lg border flex-1 overflow-y-auto">
             <h2 className="text-lg font-semibold text-foreground mb-2">
               {currentLesson.title}
             </h2>
@@ -183,9 +182,9 @@ const Index = () => {
             </div>
           </div>
         </div>
-        
+
         {/* Lesson List Sidebar */}
-        <div className="lg:col-span-2 bg-card border-r flex flex-col h-full">
+        <div className="lg:col-span-2 bg-card border-r flex flex-col h-full overflow-hidden">
           <div className="p-3 border-b bg-muted/50">
             <h3 className="font-semibold text-sm text-foreground">Course Content</h3>
             <p className="text-xs text-muted-foreground mt-1">
@@ -208,14 +207,14 @@ const Index = () => {
         </div>
 
         {/* Chat Sidebar */}
-        <div className="lg:col-span-2 bg-card border-l flex flex-col h-full">
+        <div className="lg:col-span-2 bg-card border-l flex flex-col h-full overflow-hidden">
           <div className="p-3 border-b bg-muted/50">
             <h3 className="font-semibold text-sm text-foreground">AI Assistant</h3>
             <p className="text-xs text-muted-foreground mt-1">
               Your personal tutor for questions and explanations
             </p>
           </div>
-          <div className="flex-1">
+          <div className="flex-1 overflow-hidden">
             <ChatInterface onTimestampClick={handleTimestampClick} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- lock page layout to viewport height and hide global overflow
- keep lesson list and chat panels full-height with internal scroll areas
- avoid whole-page jumps by using direct scrollTop on chat messages container

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 5 errors, 7 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b556c94ee08329b8e2a90971d01bcd